### PR TITLE
Fixed: jstree icons not displayed in category tree

### DIFF
--- a/applications/content/template/content/ContentNav.ftl
+++ b/applications/content/template/content/ContentNav.ftl
@@ -66,10 +66,12 @@ jQuery(document).ready(createTree());
  <#-------------------------------------------------------------------------------------create Tree-->
   function createTree() {
     jQuery(function () {
-        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js",
-            "/common/js/node_modules/jstree/dist/themes/default/style.min.css"], function(){
+        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js"], function(){
             jQuery("#tree").jstree({
                 "core": {
+                    "themes": {
+                        "url": "/common/js/node_modules/jstree/dist/themes/default/style.min.css"
+                    },
                     "data": rawdata,
                     "check_callback": true
                 },

--- a/applications/content/template/content/DisplayContentNav.ftl
+++ b/applications/content/template/content/DisplayContentNav.ftl
@@ -66,10 +66,12 @@ var rawdata = [
  <#-------------------------------------------------------------------------------------create Tree-->
   function createTree() {
     jQuery(function () {
-        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js",
-            "/common/js/node_modules/jstree/dist/themes/default/style.min.css"], function() {
+        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js"], function() {
             jQuery("#tree").jstree({
                 "core": {
+                   "themes": {
+                        "url": "/common/js/node_modules/jstree/dist/themes/default/style.min.css"
+                    },
                     "data": rawdata
                 },
                 "plugins": ["themes"]

--- a/applications/humanres/template/category/CategoryTree.ftl
+++ b/applications/humanres/template/category/CategoryTree.ftl
@@ -73,11 +73,13 @@ var rawdata = [
  <#-- create Tree-->
   function createTree() {
       jQuery(function () {
-        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js",
-            "/common/js/node_modules/jstree/dist/themes/default/style.min.css"], function(){
+        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js"], function(){
 
             jQuery("#tree").jstree({
                 "core": {
+                    "themes": {
+                        "url": "/common/js/node_modules/jstree/dist/themes/default/style.min.css"
+                    },
                     "data": function(node, callback) {
                         var inst = this;
                         if (node.id === '#') {

--- a/applications/product/template/category/CategoryTree.ftl
+++ b/applications/product/template/category/CategoryTree.ftl
@@ -73,13 +73,15 @@ var rawdata = [
  <#-- create Tree-->
   function createTree() {
     jQuery(function () {
-        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js",
-            "/common/js/node_modules/jstree/dist/themes/default/style.min.css"], function(){
+        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js"], function(){
             <#if stillInCatalogManager>
             localStorage.removeItem('product_category_tree');
             </#if>
             jQuery("#tree").jstree({
                 "core": {
+                    "themes": {
+                        "url": "/common/js/node_modules/jstree/dist/themes/default/style.min.css"
+                    },
                     "data": function(node, callback) {
                         var inst = this;
                         if (node.id === '#') {

--- a/applications/product/template/store/ProductStoreGroupTree.ftl
+++ b/applications/product/template/store/ProductStoreGroupTree.ftl
@@ -64,10 +64,12 @@ var rawdata = [
  <#-- create Tree-->
   function createTree() {
     jQuery(function () {
-        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js",
-            "/common/js/node_modules/jstree/dist/themes/default/style.min.css"], function(){
+        importLibrary(["/common/js/node_modules/jstree/dist/jstree.min.js"], function(){
             jQuery("#tree").jstree({
                 "core": {
+                    "themes": {
+                        "url": "/common/js/node_modules/jstree/dist/themes/default/style.min.css"
+                    },
                     "data": function(node, callback) {
                         var inst = this;
                         if (node.id === '#') {


### PR DESCRIPTION
Load the jstree theme CSS through the jstree theme configuration instead of importLibrary, so relative sprite URLs such as 32px.png resolve correctly.