### PR TITLE
Potential fix for code scanning alert no. 1512: Uncontrolled data used in path expression

### DIFF
--- a/applications/content/src/main/java/org/apache/ofbiz/content/data/DataResourceWorker.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/data/DataResourceWorker.java
@@ -1239,16 +1239,20 @@ public class DataResourceWorker implements org.apache.ofbiz.widget.content.DataR
             }
         } else if ("CONTEXT_FILE".equals(dataResourceTypeId) && UtilValidate.isNotEmpty(objectInfo)) {
             String prefix = rootDir;
-            String sep = "";
-            if (objectInfo.indexOf('/') != 0 && prefix.lastIndexOf('/') != (prefix.length() - 1)) {
-                sep = "/";
+            File file = new File(prefix, objectInfo);
+            File canonicalRoot = new File(prefix).getCanonicalFile();
+            File canonicalFile = file.getCanonicalFile();
+            String canonicalRootPath = canonicalRoot.getPath();
+            String canonicalFilePath = canonicalFile.getPath();
+            if (!canonicalFilePath.equals(canonicalRootPath)
+                    && !canonicalFilePath.startsWith(canonicalRootPath + File.separator)) {
+                throw new GeneralException("File (" + objectInfo + ") is outside of the context root");
             }
-            File file = FileUtil.getFile(prefix + sep + objectInfo);
-            checkContextFileBoundary(file, rootDir);
-            if (!file.exists()) {
-                throw new FileNotFoundException("No file found: " + file.getAbsolutePath());
+            checkContextFileBoundary(canonicalFile, rootDir);
+            if (!canonicalFile.exists()) {
+                throw new FileNotFoundException("No file found: " + canonicalFile.getAbsolutePath());
             }
-            try (InputStreamReader in = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+            try (InputStreamReader in = new InputStreamReader(new FileInputStream(canonicalFile), StandardCharsets.UTF_8)) {
                 if (Debug.infoOn()) {
                     String enc = in.getEncoding();
                     Debug.logInfo("in serveImage, encoding:" + enc, MODULE);


### PR DESCRIPTION
Potential fix for [https://github.com/jacopoc/ofbiz-framework/security/code-scanning/1512](https://github.com/jacopoc/ofbiz-framework/security/code-scanning/1512)

The safest fix is to canonicalize and validate the resolved `"CONTEXT_FILE"` path against a trusted canonical base directory (`rootDir`) before opening it, and to avoid manual string concatenation for path building.

Best fix in this snippet:
- In `applications/content/src/main/java/org/apache/ofbiz/content/data/DataResourceWorker.java`, inside `renderFile(...)`, replace the `"CONTEXT_FILE"` branch path construction:
  - build with `new File(prefix, objectInfo)` instead of `prefix + sep + objectInfo`;
  - resolve `canonicalRoot` and `canonicalFile`;
  - ensure `canonicalFile` is inside `canonicalRoot` (or equal), otherwise throw `GeneralException`;
  - use `canonicalFile` for existence check and file read.
- Keep existing behavior and `checkContextFileBoundary(...)` call (defense in depth), but enforce the canonical boundary check directly in this method so the sink is locally protected.

No new external dependency is required; only JDK `File#getCanonicalFile()` and existing exceptions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
