### PR TITLE
Potential fix for code scanning alert no. 1525: Groovy Language injection

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelTree.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelTree.java
@@ -190,6 +190,8 @@ public class ModelTree extends ModelWidget {
                 expColReq = s1;
             }
         }
+        expColReq = StringUtil.replaceString(expColReq, "${", "");
+        expColReq = StringUtil.replaceString(expColReq, "}", "");
         //append also the request parameters
         Map<String, Object> paramMap = UtilGenerics.cast(context.get("requestParameters"));
         if (UtilValidate.isNotEmpty(paramMap)) {


### PR DESCRIPTION
Potential fix for [https://github.com/jacopoc/ofbiz-framework/security/code-scanning/1525](https://github.com/jacopoc/ofbiz-framework/security/code-scanning/1525)

The safest minimal fix is to ensure request-derived URL data used as a tree link target cannot be interpreted as expression/script content by `FlexibleStringExpander`.  
Best approach without changing intended functionality: **strip any `${...}` expression markers from the request URI-derived `expColReq`** in `ModelTree.getExpandCollapseRequest(...)` before it is returned.

Concretely:
- File: `framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelTree.java`
- Method: `getExpandCollapseRequest(Map<String, Object> context)`
- After deriving `expColReq` from request URI (`s1.substring(...)`/`s1`) and before appending query parameters, neutralize expression syntax by removing `"${"` and `"}"` from `expColReq`.
- Reuse existing `StringUtil.replaceString(...)` utility (already imported), so no new dependencies/imports are required.

This preserves link behavior while preventing expression/groovy evaluation paths from being triggered by attacker-controlled URI text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
