### PR TITLE
Potential fix for code scanning alert no. 1124: Server-side request forgery

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java
@@ -422,6 +422,13 @@ public final class UtilXml {
 
     private static void validateXmlReadUrl(URL url) throws IOException {
         String protocol = url.getProtocol();
+        if (protocol == null) {
+            throw new IOException("Could not parse protocol for XML URL: " + url);
+        }
+        String normalizedProtocol = protocol.toLowerCase(java.util.Locale.ROOT);
+        if (!"file".equals(normalizedProtocol) && !"jar".equals(normalizedProtocol) && !"classpath".equals(normalizedProtocol)) {
+            throw new IOException("Reading XML from URL protocol [" + protocol + "] is not allowed: " + url);
+        }
         if (UtilValidate.isEmpty(protocol)) {
             throw new IOException("URL protocol is empty: " + url);
         }

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java
@@ -394,6 +394,7 @@ public final class UtilXml {
             Debug.logWarning("[UtilXml.readXmlDocument] URL was null, doing nothing", MODULE);
             return null;
         }
+        validateXmlReadUrl(url);
 
         URLConnection connection = url.openConnection();
         // OFBIZ-12118: Ensure caching is disabled otherwise we may find another thread has already closed the
@@ -406,33 +407,57 @@ public final class UtilXml {
 
     public static Document readXmlDocument(URL url, boolean validate, boolean withPosition)
             throws SAXException, ParserConfigurationException, java.io.IOException {
+        if (url == null) {
+            Debug.logWarning("[UtilXml.readXmlDocument] URL was null, doing nothing", MODULE);
+            return null;
+        }
+        validateXmlReadUrl(url);
 
-        // For jar: URLs (e.g. jar:http://host/file.jar!/entry), getHost() returns empty string
-        // because the host belongs to the inner URL, not the jar: wrapper. Extract it explicitly.
+        URLConnection connection = url.openConnection();
+        connection.setUseCaches(false);
+        try (InputStream is = connection.getInputStream()) {
+            return readXmlDocument(is, validate, url.toString(), withPosition);
+        }
+    }
+
+    private static void validateXmlReadUrl(URL url) throws IOException {
+        String protocol = url.getProtocol();
+        if (UtilValidate.isEmpty(protocol)) {
+            throw new IOException("URL protocol is empty: " + url);
+        }
+
+        if ("file".equals(protocol) || "classpath".equals(protocol) || "component".equals(protocol)
+                || "ofbizhome".equals(protocol)) {
+            return;
+        }
+
         String urlHost = url.getHost();
-        if (urlHost.isEmpty() && "jar".equals(url.getProtocol())) {
+        if ("jar".equals(protocol)) {
             String innerUrlStr = url.toString().substring("jar:".length());
             int bangIdx = innerUrlStr.indexOf('!');
             if (bangIdx >= 0) {
                 innerUrlStr = innerUrlStr.substring(0, bangIdx);
             }
             try {
-                urlHost = new URL(innerUrlStr).getHost();
+                URL innerUrl = new URL(innerUrlStr);
+                String innerProtocol = innerUrl.getProtocol();
+                if ("file".equals(innerProtocol)) {
+                    return;
+                }
+                urlHost = innerUrl.getHost();
             } catch (java.net.MalformedURLException e) {
                 throw new IOException("Cannot determine host from jar URL: " + url);
             }
+        } else if (!"http".equals(protocol) && !"https".equals(protocol) && !"ftp".equals(protocol)) {
+            throw new IOException("URL protocol " + protocol + " is not accepted for XML read: " + url);
         }
-        // urlHost is empty for local URLs (e.g. file:), which are always allowed
-        if (!HOSTHEADERSALLOWED.contains(urlHost) && !urlHost.isEmpty()) {
+
+        if (UtilValidate.isEmpty(urlHost) || !HOSTHEADERSALLOWED.contains(urlHost)) {
             Debug.logWarning("Domain " + urlHost + " not accepted to prevent host header injection."
                     + " You need to set host-headers-allowed property in security.properties file.", MODULE);
             throw new IOException("Domain " + urlHost + " not accepted to prevent host header injection."
                     + " You need to set host-headers-allowed property in security.properties file.");
         }
-        InputStream is = url.openStream();
-        Document document = readXmlDocument(is, validate, url.toString(), withPosition);
-        is.close();
-        return document;
     }
 
     public static Document readXmlDocument(InputStream is, String docDescription)


### PR DESCRIPTION
Potential fix for [https://github.com/jacopoc/ofbiz-framework/security/code-scanning/1124](https://github.com/jacopoc/ofbiz-framework/security/code-scanning/1124)

General fix approach: harden the URL-reading sink by enforcing a strict allowlist on URL schemes and hosts before any network/file access, and use a single validated opening path (`URLConnection` with caching disabled + try-with-resources). This prevents SSRF regardless of which upstream path provides the URL.

Best targeted fix (without changing intended functionality): in `framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java`, update both URL-based `readXmlDocument` overloads so they both call a shared validation helper that:
- permits local schemes (`file`, `jar`, `classpath`, `component`, `ofbizhome`);
- for network schemes (`http`, `https`, `ftp`), requires non-empty host and host membership in `HOSTHEADERSALLOWED` (including `jar:` inner URL host extraction);
- rejects unsupported/unknown schemes.
Then replace direct `url.openStream()` usage with `URLConnection` + `setUseCaches(false)` + try-with-resources (same style as existing 2-arg overload), ensuring consistent, safe behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
